### PR TITLE
Subtle tidy-up of the structure/styles for header/navigation

### DIFF
--- a/_collections/_objectives/o5-user-focus.html
+++ b/_collections/_objectives/o5-user-focus.html
@@ -12,7 +12,7 @@ github:
 github-src:
   repository: w3c/coga
   path: design-guide/o5-user-focus.html
-idebar:
+related:
   sections: 
     - name: User Stories
       items: "Distractions"

--- a/_collections/_patterns/o2p03-page-structure.html
+++ b/_collections/_patterns/o2p03-page-structure.html
@@ -8,7 +8,7 @@ github:
 github-src:
   repository: w3c/coga
   path: design-guide/o2p03-page-structure.html
-  related:
+related:
   sections: 
     - name: User Story
       items: "Clear Navigation"

--- a/_config.yml
+++ b/_config.yml
@@ -64,12 +64,14 @@ defaults:
       standalone_resource_about_nav:
         - name: WCAG 2
           ref: /standards-guidelines/wcag
+          icon: different-view
         - name: The WCAG 2 Documents
           ref: /standards-guidelines/wcag/docs
+          icon: different-view
         - name: Supplemental Guidance
           ref: /wcag-supplemental/about
       standalone_resource_pager:
-        icon: comments
+        icon: brain.svg
         name: All Cognitive
         ref: /wcag-supplemental/all-supplemental-guidance
       footer:
@@ -93,13 +95,13 @@ defaults:
       path: "_patterns"
     values:
       layout: pattern
-      type_of_guidance: Design Pattern
+      type_of_guidance: Cognitive Accessibility Design Pattern
   - scope:
       type: "objectives"
       path: "_objectives"
     values:
       layout: objective
-      type_of_guidance: Objective
+      type_of_guidance: Cognitive Accessibility Objective
 
 plugins:
   - jekyll-seo-tag

--- a/_config.yml
+++ b/_config.yml
@@ -54,7 +54,6 @@ defaults:
   - scope:
       path: ""
     values:
-      doc-note-type: draft
       lang: en # Change "en" to the translated-language shortcode from https://www.iana.org/assignments/language-subtag-registry/language-subtag-registry
       last_updated: 2021-@@-@@ # Put the date of this translation YYYY-MM-DD (with month in the middle)
       feedbackmail: public-cognitive-a11y-tf@w3.org # delete this line if it’s an EOWG resource (the default is wai-eo-editors@w3.org)

--- a/_config.yml
+++ b/_config.yml
@@ -73,7 +73,7 @@ defaults:
       standalone_resource_pager:
         image: brain.svg
         name: All Cognitive
-        ref: /wcag-supplemental/all-supplemental-guidance
+        ref: /wcag-supplemental/all-supplemental-guidance#-cognitive-accessibility-guidance
       footer:
         > # Translate words below, including "Date:" and "Editor:" Translate the Working Group name. Leave the Working Group acronym in English. Do *not* change the dates in the footer below.
         <p><strong>Date:</strong> Content first published 29 April 2021 in <a href="https://www.w3.org/TR/coga-usable/">Making Content 

--- a/_config_staging.yml
+++ b/_config_staging.yml
@@ -1,2 +1,3 @@
 baseurl: "/" # the subpath of your site, e.g. /blog
 url: "" # the base hostname & protocol for your site
+published: true

--- a/_includes/minimal-header.html
+++ b/_includes/minimal-header.html
@@ -1,4 +1,7 @@
-<div class="minimal-header{% if include.class %} {{ include.class }}{% endif %}" id="site-header">
+{% if include.subtitle %}
+  {% assign class_sub = "with-subtitle" %}
+{% endif %}
+<div class="minimal-header {{ class_sub }}" id="site-header">
     <span class="minimal-header-name">
         {{ include.title }}
         {% if include.subtitle %}

--- a/_layouts/standalone_resource.html
+++ b/_layouts/standalone_resource.html
@@ -110,6 +110,16 @@
   padding: 1.25em 0;
 }
 
+.nav a:link, .nav a:visited {
+  color: #036;
+  color: var(--w3c-blue);
+}
+
+.nav a:hover, .nav a:active {
+  color: #005a6a;
+  color: var(--wai-green);
+}
+
 nav.standalone-resource-about {
   padding: 1em 0;
 }

--- a/_layouts/standalone_resource.html
+++ b/_layouts/standalone_resource.html
@@ -73,13 +73,13 @@
                 <li>{%- if page.permalink == pager.ref %}<span class="pagename"><img src="/content-images/wai-wcag-supplemental/brain.svg" alt="" class="category-icon">{{pager.name}}</span>{%else%}<a href="{{pager.ref}}"><img src="/content-images/wai-wcag-supplemental/brain.svg" alt="" class="category-icon">{{pager.name}}</a>{%endif%}</li>
                 {% if page.ref %}
                     {% if context %}
-                        <li><a href="{{ context[1] }}"><svg role="img" aria-label="Parent page"  class="pager-icon" xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="currentColor" class="bi bi-caret-up" viewBox="0 0 16 16"><path d="M3.204 11h9.592L8 5.519 3.204 11zm-.753-.659 4.796-5.48a1 1 0 0 1 1.506 0l4.796 5.48c.566.647.106 1.659-.753 1.659H3.204a1 1 0 0 1-.753-1.659z"/></svg>{{ context[0] }}: {{context[2]}}</a></li>
+                        <li><a href="{{ context[1] }}"><svg role="img" aria-label="Parent page" class="pager-icon" xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="currentColor" data-class="bi bi-arrow-up-short" viewBox="0 0 16 16"><path fill-rule="evenodd" d="M8 12a.5.5 0 0 0 .5-.5V5.707l2.146 2.147a.5.5 0 0 0 .708-.708l-3-3a.5.5 0 0 0-.708 0l-3 3a.5.5 0 1 0 .708.708L7.5 5.707V11.5a.5.5 0 0 0 .5.5z"/></svg>{{ context[0] }}: {{context[2]}}</a></li>
                     {% endif %}
                     {% if prev  %}
-                        <li><a href="{{ prev[1] }}"><svg aria-hidden="true" class="pager-icon" xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="currentColor" class="bi bi-caret-left" viewBox="0 0 16 16"><path d="M10 12.796V3.204L4.519 8 10 12.796zm-.659.753-5.48-4.796a1 1 0 0 1 0-1.506l5.48-4.796A1 1 0 0 1 11 3.204v9.592a1 1 0 0 1-1.659.753z"/></svg>{{ prev[0] }}</a></li>
+                        <li><a href="{{ prev[1] }}"><svg aria-hidden="true" class="pager-icon" xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="currentColor" data-class="bi bi-arrow-left-short" viewBox="0 0 16 16"><path fill-rule="evenodd" d="M12 8a.5.5 0 0 1-.5.5H5.707l2.147 2.146a.5.5 0 0 1-.708.708l-3-3a.5.5 0 0 1 0-.708l3-3a.5.5 0 1 1 .708.708L5.707 7.5H11.5a.5.5 0 0 1 .5.5z"/></svg>{{ prev[0] }}</a></li>
                     {% endif %}
                     {% if next %}
-                        <li><a href="{{ next[1] }}">{{ next[0] }}<svg aria-hidden="true" class="pager-icon" xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="currentColor" class="bi bi-caret-right" viewBox="0 0 16 16"><path d="M6 12.796V3.204L11.481 8 6 12.796zm.659.753 5.48-4.796a1 1 0 0 0 0-1.506L6.66 2.451C6.011 1.885 5 2.345 5 3.204v9.592a1 1 0 0 0 1.659.753z"/></svg></a></li>
+                        <li><a href="{{ next[1] }}">{{ next[0] }}<svg aria-hidden="true" class="pager-icon" xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="currentColor" data-class="bi bi-arrow-right-short" viewBox="0 0 16 16"><path fill-rule="evenodd" d="M4 8a.5.5 0 0 1 .5-.5h5.793L8.146 5.354a.5.5 0 1 1 .708-.708l3 3a.5.5 0 0 1 0 .708l-3 3a.5.5 0 0 1-.708-.708L10.293 8.5H4.5A.5.5 0 0 1 4 8z"/></svg></a></li>
                     {% endif %}
                 {% endif %}
             </ul>
@@ -160,7 +160,7 @@ nav.standalone-resource-about {
 .pager-icon {
 	vertical-align: middle;
   padding: 0 0.25em 0.25em 0.25em;
-  width: 1em;
+  width: 1.5em;
   height: 2em;
   fill: #005A6A; /* when these are used as actual SVGs */
 }

--- a/_layouts/standalone_resource.html
+++ b/_layouts/standalone_resource.html
@@ -59,9 +59,7 @@
             <dl>
               <dt>About:</dt>
               {% assign docaboutnav = page.standalone_resource_about_nav %}
-              {% for link in docaboutnav %}
-                <dd><a href="{{ link.ref | relative_url }}">{{ link.name }}</a></dd>
-            {% endfor %}
+              {% for link in docaboutnav %}<dd><a href="{{ link.ref | relative_url }}">{{ link.name }}</a></dd>{% endfor %}
             </dl>
           </nav>
         </div>

--- a/_layouts/standalone_resource.html
+++ b/_layouts/standalone_resource.html
@@ -150,16 +150,14 @@
 }
 
 .nav a:hover, .nav a:active {
-  color: #005a6a;
-  color: var(--wai-green);
+    color: var(--dk-blue);
 }
 
 .nav-hack.sidebar a:hover,
-.nav-hack.sidebar a:focus
+.nav-hack.sidebar a:active
  {
-  color: #005a6a;
-  color: var(--wai-green);
-  text-decoration: underline;
+    color: var(--dk-blue);
+    text-decoration: underline;
 }
 
 .standalone-resource-about, .standalone-resource-pager {

--- a/_layouts/standalone_resource.html
+++ b/_layouts/standalone_resource.html
@@ -115,7 +115,6 @@
     <div class="default-grid with-gap leftcol">
 
 <style>
-/* Patrick H. Lauke additions */
 #site-header.minimal-header.with-subtitle {
   padding: 1.75em 0 0 0;
 }
@@ -160,7 +159,8 @@
 }
 
 nav.standalone-resource-about {
-  padding: 1em 0 1.5em 0;
+  padding: .5em 0 1.0em 0;
+  font-style: italic;
 }
 
 .standalone-resource-about dl, .standalone-resource-about dt, .standalone-resource-about dd {
@@ -171,20 +171,24 @@ nav.standalone-resource-about {
 
 .standalone-resource-about dt{
     font-weight: normal;
-    font-style: italic;
 }
 
 .standalone-resource-about dl a {
-	margin: 0;
-  padding: 0 1em 0 1em;
+    margin: 0;
+    padding: 0 1em 0 1em;
 }
 
 .standalone-resource-about dd {
-  border-right: 1px var(--gold) solid;
+    border-right: 1px var(--gold) solid;
 }
 
 .standalone-resource-about dd:last-of-type {
 	border-right: 0;
+}
+
+.standalone-resource-about dd svg {
+    margin-left: 0.25rem;
+    vertical-align: middle;
 }
 
 .nav .standalone-resource-pager ul {
@@ -223,9 +227,6 @@ nav.standalone-resource-about {
 .standalone-resource-pager ul li {
   display: inline;
 }
-
-/* end Patrick H. Lauke additions */
-
 
 .nav-hack {
   font-size: .85rem;
@@ -282,7 +283,7 @@ nav.standalone-resource-about {
 .minimal-header-subtitle {
   display: block;
   font-size: 60%;
-  margin-top: 0.5em;
+  margin-top: 1.5em;
   font-style: italic;
 }
 
@@ -290,14 +291,6 @@ nav.standalone-resource-about {
     border:none;
     border-top: 1px solid grey
 }
-
-/* Removed by Patrick H. Lauke (as it's being overridden anyway)
-.standalone-resource-about,
-.standalone-resource-pager {
-    margin-top: .5em;
-    margin-left: .5em;
-}
-*/
 
 .standalone-resource-about ul,
 .standalone-resource-pager ul {
@@ -383,97 +376,7 @@ nav.standalone-resource-about {
   {% include footer.html lang=pagelang %}
 
   
-  <style>
-
-    .nav-hack {
-      font-size: .85rem;
-      /*justify-self: end;*/
-      align-self: start;
-    }
-    .nav-hack ul {
-        list-style: none;
-        border-bottom: 1px solid #BCBCBC;
-        padding-left: 0
-    }
-    .nav-hack li:not(:first-child){
-        padding-top: 0.4em;
-        line-height: 1.2;
-        border-top: 1px solid #BCBCBC;
-    }
-    .nav-hack li a {
-        text-decoration: none;
-    }
-    .nav-hack h3 {
-      margin: 0;
-      font-size: 1rem;
-    }
-    
-    .nav-hack p {
-      margin: 0;
-    }
-    
-    
-    /* skip link */
-    .button--skip-link {
-      background-color: var(--gold) !important;
-      border-color: var(--gold) !important;
-      outline-color: currentColor !important;
-      color: var(--off-black) !important;
-      font-weight: 600;
-      font-size: larger;
-      margin: 0 auto;
-      position: absolute;
-      z-index: 20;
-      left: 0;
-      right: 0;
-      top: 0.5em;
-      width: 10em;
-      opacity: 1;
-      transition: transform 0.1875s ease-out, opacity 0.1875s ease-out;
-    }
-    
-    .button--skip-link:not(:focus):not(:hover) {
-      transform: translateY(-4em);
-      opacity: 0;
-    }
-    
-    .minimal-header-subtitle {
-      display: block;
-      font-size: 60%;
-      margin-top: 1em;
-      font-style: italic;
-    }
-    
-    .standalone-resource-navrule {
-        border:none;
-        border-top: 1px solid grey
-    }
-    
-    .standalone-resource-about,
-    .standalone-resource-pager {
-        margin-top: .5em;
-        margin-left: .5em;
-    }
-    
-    .standalone-resource-about ul,
-    .standalone-resource-pager ul {
-        list-style: none;
-    }
-    
-    .nav {
-        font-size: 85%;
-    }
-    
-    .standalone-resource-about a,
-    .standalone-resource-pager a,
-    .standalone-resource-about span,
-    .standalone-resource-pager span 
-    {
-        margin-left:.8em;
-        margin-right:.8em;
-    }
-    
-    </style>
+  
     
   </body>
 

--- a/_layouts/standalone_resource.html
+++ b/_layouts/standalone_resource.html
@@ -70,23 +70,23 @@
         <nav class="standalone-resource-pager" aria-label="Item navigation">
             {% include dg-nav.liquid %}
             <ul>
-                <li>{%- if page.permalink == pager.ref %}<span class="pagename">{{pager.name}}</span>{%else%}<img src="/content-images/wai-wcag-supplemental/brain.svg" alt="" class="pager-icon" /> <a href="{{pager.ref}}">{{pager.name}}</a>{%endif%}</li>
+                <li>{%- if page.permalink == pager.ref %}<span class="pagename">{{pager.name}}</span>{%else%}<a href="{{pager.ref}}"><img src="/content-images/wai-wcag-supplemental/brain.svg" alt="" class="category-icon">{{pager.name}}</a>{%endif%}</li>
                 {% if page.ref %}
                     {% if context %}
-                        <li><a href="{{ context[1] }}">{% include_cached icon.html name="arrow-up" aria-label="Parent item"%} {{ context[0] }}: {{context[2]}}</a></li>
+                        <li><a href="{{ context[1] }}"><img src="/content-images/wai-wcag-supplemental/caret-up.svg" alt="Parent page" class="pager-icon">{{ context[0] }}: {{context[2]}}</a></li>
                     {% endif %}
                     {% if prev  %}
-                        <li><a href="{{ prev[1] }}">{% include_cached icon.html name="arrow-left" %} {{ prev[0] }}</a></li>
+                        <li><a href="{{ prev[1] }}"><img src="/content-images/wai-wcag-supplemental/caret-left.svg" alt="" class="pager-icon">{{ prev[0] }}</a></li>
                     {% endif %}
                     {% if next %}
-                        <li><a href="{{ next[1] }}">{% include_cached icon.html name="arrow-right" %} {{ next[0] }}</a></li>
+                        <li><a href="{{ next[1] }}">{{ next[0] }}<img src="/content-images/wai-wcag-supplemental/caret-right.svg" alt="" class="pager-icon"></a></li>
                     {% endif %}
                 {% endif %}
             </ul>
         </nav>
         </div>
         {% elsif site.standalone_resource_nav_links or page.standalone_resource_nav_links %}
-           <nav class="nav" aria-label="Context for this document">
+          <nav class="nav" aria-label="Context for this document">
             <ul>
             {% for link in site.standalone_resource_nav_links %}
                 <li class="nav__item"><a href="{{ link.ref | relative_url }}"{% if page.permalink == link.ref %} class="active" aria-current="page"{% endif %}>{{ link.name }}</a></li>
@@ -107,11 +107,11 @@
 <style>
 /* Patrick H. Lauke additions */
 #site-header.minimal-header.with-subtitle {
-	padding: 1.25em 0;
+  padding: 1.25em 0;
 }
 
 nav.standalone-resource-about {
-    padding: 1em 0;
+  padding: 1em 0;
 }
 
 .standalone-resource-about dl, .standalone-resource-about dt, .standalone-resource-about dd {
@@ -122,23 +122,38 @@ nav.standalone-resource-about {
 
 .standalone-resource-about dl a {
 	margin: 0;
-    padding: 0 1em 0 1em;
-    border-right: 1px #999 solid;
+  padding: 0 1em 0 1em;
+  border-right: 1px #999 solid;
 }
 
 .standalone-resource-about dd:last-of-type a {
 	border-right: 0;
 }
 
+.nav .standalone-resource-pager ul {
+  align-items: center;
+}
+
+.nav .standalone-resource-pager a {
+  margin-left: 0;
+}
+
 .pager-icon {
 	vertical-align: middle;
-    padding-bottom: 0.25em;
-    width: 2em;
-    height: 2em;
+  padding: 0 0.25em 0.25em 0.25em;
+  width: 1em;
+  height: 2em;
+  fill: #005A6A; /* when these are used as actual SVGs */
+}
+
+.category-icon {
+  vertical-align: middle;
+  padding: 0 0.25em 0.25em 0.25em;
+  width: 2em;
+  height: 2em;
 }
 
 /* end Patrick H. Lauke additions */
-
 
 
 .nav-hack {

--- a/_layouts/standalone_resource.html
+++ b/_layouts/standalone_resource.html
@@ -92,7 +92,7 @@
                         <li><a href="{{ prev[1] }}">{% include_cached icon.html class="pager-icon" name="arrow-left-thin" %} {{ prev[0] }}</a></li>
                     {% endif %}
                     {% if next %}
-                        <li><a href="{{ next[1] }}">{% include_cached icon.html class="pager-icon" name="arrow-right-thin" %} {{ next[0] }}</a></li>
+                        <li><a href="{{ next[1] }}">{{ next[0] }} {% include_cached icon.html class="pager-icon" name="arrow-right-thin" %}</a></li>
                     {% endif %}
                 {% endif %}
             </ul>
@@ -152,6 +152,14 @@
 .nav a:hover, .nav a:active {
   color: #005a6a;
   color: var(--wai-green);
+}
+
+.nav-hack.sidebar a:hover,
+.nav-hack.sidebar a:focus
+ {
+  color: #005a6a;
+  color: var(--wai-green);
+  text-decoration: underline;
 }
 
 .standalone-resource-about, .standalone-resource-pager {

--- a/_layouts/standalone_resource.html
+++ b/_layouts/standalone_resource.html
@@ -52,9 +52,9 @@
       {% endif %}
     </div>
 
-    <div class="default-grid nav-container">
+    {% if page.standalone_resource_about_nav %}
+    <div class="default-grid nav-container nav-related-info">
         <div class="nav">
-          {% if page.standalone_resource_about_nav %} 
           <nav class="standalone-resource-about" aria-label="Related information">
             <dl>
               <dt>About:</dt>
@@ -63,11 +63,15 @@
                 <dd><a href="{{ link.ref | relative_url }}">{{ link.name }}</a></dd>
             {% endfor %}
             </dl>
-        </nav>
-        {% endif %}
-        {% if page.standalone_resource_about_nav %}
-        {% assign pager = page.standalone_resource_pager %}
-        <nav class="standalone-resource-pager" aria-label="Item navigation">
+          </nav>
+        </div>
+    </div>
+    {% endif %}
+    <div class="default-grid nav-container nav-page-specific">
+        <div class="nav">
+          {% if page.standalone_resource_about_nav %}
+          {% assign pager = page.standalone_resource_pager %}
+          <nav class="standalone-resource-pager" aria-label="Item navigation">
             {% include dg-nav.liquid %}
             <ul>
                 <li>{%- if page.permalink == pager.ref %}<span class="pagename"><img src="/content-images/wai-wcag-supplemental/brain.svg" alt="" class="category-icon">{{pager.name}}</span>{%else%}<a href="{{pager.ref}}"><img src="/content-images/wai-wcag-supplemental/brain.svg" alt="" class="category-icon">{{pager.name}}</a>{%endif%}</li>
@@ -83,9 +87,8 @@
                     {% endif %}
                 {% endif %}
             </ul>
-        </nav>
-        </div>
-        {% elsif site.standalone_resource_nav_links or page.standalone_resource_nav_links %}
+          </nav>
+          {% elsif site.standalone_resource_nav_links or page.standalone_resource_nav_links %}
           <nav class="nav" aria-label="Context for this document">
             <ul>
             {% for link in site.standalone_resource_nav_links %}
@@ -99,19 +102,41 @@
                 {% include_cached icon.html name="different-view" %}
             </a></li>
             </ul>
-        </nav>
-      {% endif %}
-</div>
+          </nav>
+          {% endif %}
+        </div>
+    </div>
     <div class="default-grid with-gap leftcol">
 
 <style>
 /* Patrick H. Lauke additions */
 #site-header.minimal-header.with-subtitle {
-  padding: 1.5em 0;
+  padding: 1.75em 0 0 0;
 }
 
 .minimal-header.with-subtitle .minimal-header-name {
   font-size: 1.5em;
+}
+
+.nav-container {
+  margin-bottom: 0;
+}
+
+.nav {
+  background: none;
+}
+
+.nav-related-info { /* blue bar with the "About:" links */
+  background: #005a9c;
+  color: #fff;
+}
+
+.nav-related-info a {
+  color: #fff !important;
+}
+
+.nav-page-specific { /* light blue bar with page/section specific navigation/pager */
+  margin-bottom: 1.25em;
 }
 
 .nav a:link, .nav a:visited {
@@ -125,11 +150,11 @@
 }
 
 .standalone-resource-about, .standalone-resource-pager {
-  margin: 0 !important;
+  margin: 0;
 }
 
 nav.standalone-resource-about {
-  padding: 1.5em 0;
+  padding: 1em 0 1.5em 0;
 }
 
 .standalone-resource-about dl, .standalone-resource-about dt, .standalone-resource-about dd {
@@ -163,8 +188,8 @@ nav.standalone-resource-about {
 
 .pager-icon {
 	vertical-align: middle;
-  padding: 0 0.25em 0.25em 0.25em;
-  width: 1.5em;
+  padding: 0 0.15em 0.15em 0.15em;
+  width: 1.65em;
   height: 2em;
   fill: #005A6A; /* when these are used as actual SVGs */
 }
@@ -177,7 +202,7 @@ nav.standalone-resource-about {
 }
 
 .standalone-resource-pager {
-  padding-bottom: 1em;
+  padding: 1em 0;
 }
 
 .standalone-resource-pager ul {
@@ -255,11 +280,13 @@ nav.standalone-resource-about {
     border-top: 1px solid grey
 }
 
+/* Removed by Patrick H. Lauke (as it's being overridden anyway)
 .standalone-resource-about,
 .standalone-resource-pager {
     margin-top: .5em;
     margin-left: .5em;
 }
+*/
 
 .standalone-resource-about ul,
 .standalone-resource-pager ul {
@@ -327,7 +354,7 @@ nav.standalone-resource-about {
                 Rule Mapping 
               </header>
               <div class="box-i"> 
-               <p>This is {% if page.rule_meta.rule_type == "atomic" %}an {% else %}a {% endif %}
+                <p>This is {% if page.rule_meta.rule_type == "atomic" %}an {% else %}a {% endif %}
                 <strong>{{ page.rule_meta.rule_type | capitalize }} rule</strong> 
                 {% if page.rule_meta.scs_tested %}
                 to test 
@@ -335,9 +362,9 @@ nav.standalone-resource-about {
                 <strong>{{ sc.num }}: {{ sc.handle }} (Level {{ sc.level }})</strong>{% if forloop.last == false %}, {% endif %}
                 {% endfor %}
                 {% endif %}
-              </p> 
+                </p> 
               </div>
-             </aside>
+            </aside>
             {% endif %}
           </header>
     

--- a/_layouts/standalone_resource.html
+++ b/_layouts/standalone_resource.html
@@ -167,7 +167,7 @@ nav.standalone-resource-about {
 }
 
 .standalone-resource-about dd {
-  border-right: 1px #999 solid;
+  border-right: 1px var(--gold) solid;
 }
 
 .standalone-resource-about dd:last-of-type {

--- a/_layouts/standalone_resource.html
+++ b/_layouts/standalone_resource.html
@@ -107,7 +107,7 @@
 <style>
 /* Patrick H. Lauke additions */
 #site-header.minimal-header.with-subtitle {
-  padding: 1.5em 0;
+  padding: 1.2em 0;
 }
 
 .nav a:link, .nav a:visited {

--- a/_layouts/standalone_resource.html
+++ b/_layouts/standalone_resource.html
@@ -70,7 +70,7 @@
         <nav class="standalone-resource-pager" aria-label="Item navigation">
             {% include dg-nav.liquid %}
             <ul>
-                <li>{%- if page.permalink == pager.ref %}<span class="pagename">{{pager.name}}</span>{%else%}<a href="{{pager.ref}}"><img src="/content-images/wai-wcag-supplemental/brain.svg" alt="" class="category-icon">{{pager.name}}</a>{%endif%}</li>
+                <li>{%- if page.permalink == pager.ref %}<span class="pagename"><img src="/content-images/wai-wcag-supplemental/brain.svg" alt="" class="category-icon">{{pager.name}}</span>{%else%}<a href="{{pager.ref}}"><img src="/content-images/wai-wcag-supplemental/brain.svg" alt="" class="category-icon">{{pager.name}}</a>{%endif%}</li>
                 {% if page.ref %}
                     {% if context %}
                         <li><a href="{{ context[1] }}"><svg role="img" aria-label="Parent page"  class="pager-icon" xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="currentColor" class="bi bi-caret-up" viewBox="0 0 16 16"><path d="M3.204 11h9.592L8 5.519 3.204 11zm-.753-.659 4.796-5.48a1 1 0 0 1 1.506 0l4.796 5.48c.566.647.106 1.659-.753 1.659H3.204a1 1 0 0 1-.753-1.659z"/></svg>{{ context[0] }}: {{context[2]}}</a></li>
@@ -120,8 +120,12 @@
   color: var(--wai-green);
 }
 
+.standalone-resource-about, .standalone-resource-pager {
+  margin: 0 !important;
+}
+
 nav.standalone-resource-about {
-  padding: 1em 0;
+  padding: 1.5em 0;
 }
 
 .standalone-resource-about dl, .standalone-resource-about dt, .standalone-resource-about dd {
@@ -144,7 +148,8 @@ nav.standalone-resource-about {
   align-items: center;
 }
 
-.nav .standalone-resource-pager a {
+.nav .standalone-resource-pager a,
+.nav .standalone-resource-pager span {
   margin-left: 0;
   margin-right: 1.5em;
 }

--- a/_layouts/standalone_resource.html
+++ b/_layouts/standalone_resource.html
@@ -73,13 +73,13 @@
                 <li>{%- if page.permalink == pager.ref %}<span class="pagename">{{pager.name}}</span>{%else%}<a href="{{pager.ref}}"><img src="/content-images/wai-wcag-supplemental/brain.svg" alt="" class="category-icon">{{pager.name}}</a>{%endif%}</li>
                 {% if page.ref %}
                     {% if context %}
-                        <li><a href="{{ context[1] }}"><img src="/content-images/wai-wcag-supplemental/caret-up.svg" alt="Parent page" class="pager-icon">{{ context[0] }}: {{context[2]}}</a></li>
+                        <li><a href="{{ context[1] }}"><svg role="img" aria-label="Parent page"  class="pager-icon" xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="currentColor" class="bi bi-caret-up" viewBox="0 0 16 16"><path d="M3.204 11h9.592L8 5.519 3.204 11zm-.753-.659 4.796-5.48a1 1 0 0 1 1.506 0l4.796 5.48c.566.647.106 1.659-.753 1.659H3.204a1 1 0 0 1-.753-1.659z"/></svg>{{ context[0] }}: {{context[2]}}</a></li>
                     {% endif %}
                     {% if prev  %}
-                        <li><a href="{{ prev[1] }}"><img src="/content-images/wai-wcag-supplemental/caret-left.svg" alt="" class="pager-icon">{{ prev[0] }}</a></li>
+                        <li><a href="{{ prev[1] }}"><svg aria-hidden="true" class="pager-icon" xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="currentColor" class="bi bi-caret-left" viewBox="0 0 16 16"><path d="M10 12.796V3.204L4.519 8 10 12.796zm-.659.753-5.48-4.796a1 1 0 0 1 0-1.506l5.48-4.796A1 1 0 0 1 11 3.204v9.592a1 1 0 0 1-1.659.753z"/></svg>{{ prev[0] }}</a></li>
                     {% endif %}
                     {% if next %}
-                        <li><a href="{{ next[1] }}">{{ next[0] }}<img src="/content-images/wai-wcag-supplemental/caret-right.svg" alt="" class="pager-icon"></a></li>
+                        <li><a href="{{ next[1] }}">{{ next[0] }}<svg aria-hidden="true" class="pager-icon" xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="currentColor" class="bi bi-caret-right" viewBox="0 0 16 16"><path d="M6 12.796V3.204L11.481 8 6 12.796zm.659.753 5.48-4.796a1 1 0 0 0 0-1.506L6.66 2.451C6.011 1.885 5 2.345 5 3.204v9.592a1 1 0 0 0 1.659.753z"/></svg></a></li>
                     {% endif %}
                 {% endif %}
             </ul>
@@ -146,6 +146,7 @@ nav.standalone-resource-about {
 
 .nav .standalone-resource-pager a {
   margin-left: 0;
+  margin-right: 1.5em;
 }
 
 .pager-icon {

--- a/_layouts/standalone_resource.html
+++ b/_layouts/standalone_resource.html
@@ -70,11 +70,7 @@
         <nav class="standalone-resource-pager" aria-label="Item navigation">
             {% include dg-nav.liquid %}
             <ul>
-<<<<<<< HEAD
                 <li>{%- if page.permalink == pager.ref %}<span class="pagename">{{pager.name}}</span>{%else%}<img src="/content-images/wai-wcag-supplemental/brain.svg" alt="" class="pager-icon" /> <a href="{{pager.ref}}">{{pager.name}}</a>{%endif%}</li>
-=======
-                <li>{%- if page.permalink == pager.ref %}<span class="pagename">{{pager.name}}</span>{%else%}><img src="/content-images/wai-wcag-supplemental/brain.svg" alt="" style="height: 1.8em;" /> <a href="{{pager.ref}}">{{pager.name}}</a>{%endif%}</li>
->>>>>>> f9efed2df9692e2387ce91ca3b98df55fea582ae
                 {% if page.ref %}
                     {% if context %}
                         <li><a href="{{ context[1] }}">{% include_cached icon.html name="arrow-up" aria-label="Parent item"%} {{ context[0] }}: {{context[2]}}</a></li>
@@ -109,6 +105,41 @@
     <div class="default-grid with-gap leftcol">
 
 <style>
+/* Patrick H. Lauke additions */
+#site-header.minimal-header.with-subtitle {
+	padding: 1.25em 0;
+}
+
+nav.standalone-resource-about {
+    padding: 1em 0;
+}
+
+.standalone-resource-about dl, .standalone-resource-about dt, .standalone-resource-about dd {
+	display: inline;
+	margin: 0;
+	padding: 0;
+}
+
+.standalone-resource-about dl a {
+	margin: 0;
+    padding: 0 1em 0 1em;
+    border-right: 1px #999 solid;
+}
+
+.standalone-resource-about dd:last-of-type a {
+	border-right: 0;
+}
+
+.pager-icon {
+	vertical-align: middle;
+    padding-bottom: 0.25em;
+    width: 2em;
+    height: 2em;
+}
+
+/* end Patrick H. Lauke additions */
+
+
 
 .nav-hack {
   font-size: .85rem;

--- a/_layouts/standalone_resource.html
+++ b/_layouts/standalone_resource.html
@@ -137,10 +137,13 @@ nav.standalone-resource-about {
 .standalone-resource-about dl a {
 	margin: 0;
   padding: 0 1em 0 1em;
+}
+
+.standalone-resource-about dd {
   border-right: 1px #999 solid;
 }
 
-.standalone-resource-about dd:last-of-type a {
+.standalone-resource-about dd:last-of-type {
 	border-right: 0;
 }
 

--- a/_layouts/standalone_resource.html
+++ b/_layouts/standalone_resource.html
@@ -57,7 +57,7 @@
           {% if page.standalone_resource_about_nav %} 
           <nav class="standalone-resource-about" aria-label="Related information">
             <dl>
-              <dt>About:</dt>
+              <dt>Related information:</dt>
               {% assign docaboutnav = page.standalone_resource_about_nav %}
               {% for link in docaboutnav %}
                 <dd><a href="{{ link.ref | relative_url }}">{{ link.name }}</a></dd>
@@ -70,8 +70,7 @@
         <nav class="standalone-resource-pager" aria-label="Item navigation">
             {% include dg-nav.liquid %}
             <ul>
-                <li><img src="/content-images/wai-wcag-supplemental/brain.svg" alt="" style="height: 1.8em;" /></li>
-                <li>{%- if page.permalink == pager.ref %}<span class="pagename">{{pager.name}}</span>{%else%}<a href="{{pager.ref}}">{{pager.name}}</a>{%endif%}</li>
+                <li>{%- if page.permalink == pager.ref %}<span class="pagename">{{pager.name}}</span>{%else%}<img src="/content-images/wai-wcag-supplemental/brain.svg" alt="" class="pager-icon" /> <a href="{{pager.ref}}">{{pager.name}}</a>{%endif%}</li>
                 {% if page.ref %}
                     {% if context %}
                         <li><a href="{{ context[1] }}">{% include_cached icon.html name="arrow-up" aria-label="Parent item"%} {{ context[0] }}: {{context[2]}}</a></li>

--- a/_layouts/standalone_resource.html
+++ b/_layouts/standalone_resource.html
@@ -75,13 +75,13 @@
                 <li>{%- if page.permalink == pager.ref %}<span class="pagename"><img src="/content-images/wai-wcag-supplemental/brain.svg" alt="" class="category-icon">{{pager.name}}</span>{%else%}<a href="{{pager.ref}}"><img src="/content-images/wai-wcag-supplemental/brain.svg" alt="" class="category-icon">{{pager.name}}</a>{%endif%}</li>
                 {% if page.ref %}
                     {% if context %}
-                        <li><a href="{{ context[1] }}"><svg role="img" aria-label="Parent page" class="pager-icon" xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="currentColor" data-class="bi bi-arrow-up-short" viewBox="0 0 16 16"><path fill-rule="evenodd" d="M8 12a.5.5 0 0 0 .5-.5V5.707l2.146 2.147a.5.5 0 0 0 .708-.708l-3-3a.5.5 0 0 0-.708 0l-3 3a.5.5 0 1 0 .708.708L7.5 5.707V11.5a.5.5 0 0 0 .5.5z"/></svg>{{ context[0] }}: {{context[2]}}</a></li>
+                        <li><a href="{{ context[1] }}">{% include_cached icon.html class="pager-icon" name="arrow-up-thin" %} {{ context[0] }}: {{context[2]}}</a></li>
                     {% endif %}
                     {% if prev  %}
-                        <li><a href="{{ prev[1] }}"><svg aria-hidden="true" class="pager-icon" xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="currentColor" data-class="bi bi-arrow-left-short" viewBox="0 0 16 16"><path fill-rule="evenodd" d="M12 8a.5.5 0 0 1-.5.5H5.707l2.147 2.146a.5.5 0 0 1-.708.708l-3-3a.5.5 0 0 1 0-.708l3-3a.5.5 0 1 1 .708.708L5.707 7.5H11.5a.5.5 0 0 1 .5.5z"/></svg>{{ prev[0] }}</a></li>
+                        <li><a href="{{ prev[1] }}">{% include_cached icon.html class="pager-icon" name="arrow-left-thin" %} {{ prev[0] }}</a></li>
                     {% endif %}
                     {% if next %}
-                        <li><a href="{{ next[1] }}">{{ next[0] }}<svg aria-hidden="true" class="pager-icon" xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="currentColor" data-class="bi bi-arrow-right-short" viewBox="0 0 16 16"><path fill-rule="evenodd" d="M4 8a.5.5 0 0 1 .5-.5h5.793L8.146 5.354a.5.5 0 1 1 .708-.708l3 3a.5.5 0 0 1 0 .708l-3 3a.5.5 0 0 1-.708-.708L10.293 8.5H4.5A.5.5 0 0 1 4 8z"/></svg></a></li>
+                        <li><a href="{{ next[1] }}">{% include_cached icon.html class="pager-icon" name="arrow-right-thin" %} {{ next[0] }}</a></li>
                     {% endif %}
                 {% endif %}
             </ul>

--- a/_layouts/standalone_resource.html
+++ b/_layouts/standalone_resource.html
@@ -107,7 +107,11 @@
 <style>
 /* Patrick H. Lauke additions */
 #site-header.minimal-header.with-subtitle {
-  padding: 1.2em 0;
+  padding: 1.5em 0;
+}
+
+.minimal-header.with-subtitle .minimal-header-name {
+  font-size: 1.5em;
 }
 
 .nav a:link, .nav a:visited {
@@ -242,7 +246,7 @@ nav.standalone-resource-about {
 .minimal-header-subtitle {
   display: block;
   font-size: 60%;
-  margin-top: 1em;
+  margin-top: 0.5em;
   font-style: italic;
 }
 

--- a/_layouts/standalone_resource.html
+++ b/_layouts/standalone_resource.html
@@ -78,9 +78,9 @@
             <ul>
                 <li>
                 {%- if page.permalink == pager.ref %}
-                <span class="pagename"><img src="/content-images/wai-wcag-supplemental/brain.svg" alt="" class="category-icon">{{pager.name}}</span>
+                    <span class="pagename"><img src="/content-images/wai-wcag-supplemental/brain.svg" alt="" class="category-icon">{{pager.name}}</span>
                 {%else%}
-                <a href="{{pager.ref}}"><img src="/content-images/wai-wcag-supplemental/brain.svg" alt="" class="category-icon">{{pager.name}}</a>
+                    <a href="{{pager.ref}}"><img src="/content-images/wai-wcag-supplemental/brain.svg" alt="" class="category-icon">{{pager.name}}</a>
                 {%endif%}
                 </li>
         
@@ -159,7 +159,7 @@
 }
 
 nav.standalone-resource-about {
-  padding: .5em 0 1.0em 0;
+  padding: .5em 0 1.5em 0;
   font-style: italic;
 }
 

--- a/_layouts/standalone_resource.html
+++ b/_layouts/standalone_resource.html
@@ -57,7 +57,7 @@
           {% if page.standalone_resource_about_nav %} 
           <nav class="standalone-resource-about" aria-label="Related information">
             <dl>
-              <dt>Related information:</dt>
+              <dt>About:</dt>
               {% assign docaboutnav = page.standalone_resource_about_nav %}
               {% for link in docaboutnav %}
                 <dd><a href="{{ link.ref | relative_url }}">{{ link.name }}</a></dd>
@@ -107,7 +107,7 @@
 <style>
 /* Patrick H. Lauke additions */
 #site-header.minimal-header.with-subtitle {
-  padding: 1.25em 0;
+  padding: 1.5em 0;
 }
 
 .nav a:link, .nav a:visited {

--- a/_layouts/standalone_resource.html
+++ b/_layouts/standalone_resource.html
@@ -54,24 +54,16 @@
 
     <div class="default-grid nav-container">
         <div class="nav">
-        <nav class="standalone-resource-about" aria-label="Related information">
-            {% if page.standalone_resource_about_nav %}     
-            {% assign docaboutnav = page.standalone_resource_about_nav %}
-            {% assign aboutnav = '<em>About:</em><span class="standalone_resource_aboutnavsep"></span>' %}
-            {% for link in docaboutnav %}
-                {% capture navitem %}<li><a href="{{ link.ref | relative_url }}">{{ link.name }}</a></li>{% endcapture %}
-                {% if forloop.last == true %}
-                    {% assign sep = "" %}
-                {% else %}
-                    {% assign sep = '<span class="standalone_resource_aboutnavsep">  </span>' %}
-                {% endif %}
-                {% assign aboutnav = aboutnav | append: navitem | append: sep %} 
+          {% if page.standalone_resource_about_nav %} 
+          <nav class="standalone-resource-about" aria-label="Related information">
+            <dl>
+              <dt>About:</dt>
+              {% assign docaboutnav = page.standalone_resource_about_nav %}
+              {% for link in docaboutnav %}
+                <dd><a href="{{ link.ref | relative_url }}">{{ link.name }}</a></dd>
             {% endfor %}
-            <ul>{{ aboutnav }}</ul>
-            {% endif %}
+            </dl>
         </nav>
-        {% if page.standalone_resource_pager and page.standalone_resource_about_nav %}
-        <hr class="standalone-resource-navrule"/>
         {% endif %}
         {% if page.standalone_resource_about_nav %}
         {% assign pager = page.standalone_resource_pager %}

--- a/_layouts/standalone_resource.html
+++ b/_layouts/standalone_resource.html
@@ -169,6 +169,18 @@ nav.standalone-resource-about {
   height: 2em;
 }
 
+.standalone-resource-pager {
+  padding-bottom: 1em;
+}
+
+.standalone-resource-pager ul {
+  display: block;
+}
+
+.standalone-resource-pager ul li {
+  display: inline;
+}
+
 /* end Patrick H. Lauke additions */
 
 

--- a/content-images/wai-wcag-supplemental/arrow-left-short.svg
+++ b/content-images/wai-wcag-supplemental/arrow-left-short.svg
@@ -1,0 +1,3 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="currentColor" class="bi bi-arrow-left-short" viewBox="0 0 16 16">
+  <path fill-rule="evenodd" d="M12 8a.5.5 0 0 1-.5.5H5.707l2.147 2.146a.5.5 0 0 1-.708.708l-3-3a.5.5 0 0 1 0-.708l3-3a.5.5 0 1 1 .708.708L5.707 7.5H11.5a.5.5 0 0 1 .5.5z"/>
+</svg>

--- a/content-images/wai-wcag-supplemental/arrow-left-short.svg
+++ b/content-images/wai-wcag-supplemental/arrow-left-short.svg
@@ -1,3 +1,0 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="currentColor" class="bi bi-arrow-left-short" viewBox="0 0 16 16">
-  <path fill-rule="evenodd" d="M12 8a.5.5 0 0 1-.5.5H5.707l2.147 2.146a.5.5 0 0 1-.708.708l-3-3a.5.5 0 0 1 0-.708l3-3a.5.5 0 1 1 .708.708L5.707 7.5H11.5a.5.5 0 0 1 .5.5z"/>
-</svg>

--- a/content-images/wai-wcag-supplemental/arrow-right-short.svg
+++ b/content-images/wai-wcag-supplemental/arrow-right-short.svg
@@ -1,0 +1,3 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="currentColor" class="bi bi-arrow-right-short" viewBox="0 0 16 16">
+  <path fill-rule="evenodd" d="M4 8a.5.5 0 0 1 .5-.5h5.793L8.146 5.354a.5.5 0 1 1 .708-.708l3 3a.5.5 0 0 1 0 .708l-3 3a.5.5 0 0 1-.708-.708L10.293 8.5H4.5A.5.5 0 0 1 4 8z"/>
+</svg>

--- a/content-images/wai-wcag-supplemental/arrow-right-short.svg
+++ b/content-images/wai-wcag-supplemental/arrow-right-short.svg
@@ -1,3 +1,0 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="currentColor" class="bi bi-arrow-right-short" viewBox="0 0 16 16">
-  <path fill-rule="evenodd" d="M4 8a.5.5 0 0 1 .5-.5h5.793L8.146 5.354a.5.5 0 1 1 .708-.708l3 3a.5.5 0 0 1 0 .708l-3 3a.5.5 0 0 1-.708-.708L10.293 8.5H4.5A.5.5 0 0 1 4 8z"/>
-</svg>

--- a/content-images/wai-wcag-supplemental/arrow-up-short.svg
+++ b/content-images/wai-wcag-supplemental/arrow-up-short.svg
@@ -1,0 +1,3 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="currentColor" class="bi bi-arrow-up-short" viewBox="0 0 16 16">
+  <path fill-rule="evenodd" d="M8 12a.5.5 0 0 0 .5-.5V5.707l2.146 2.147a.5.5 0 0 0 .708-.708l-3-3a.5.5 0 0 0-.708 0l-3 3a.5.5 0 1 0 .708.708L7.5 5.707V11.5a.5.5 0 0 0 .5.5z"/>
+</svg>

--- a/content-images/wai-wcag-supplemental/arrow-up-short.svg
+++ b/content-images/wai-wcag-supplemental/arrow-up-short.svg
@@ -1,3 +1,0 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="currentColor" class="bi bi-arrow-up-short" viewBox="0 0 16 16">
-  <path fill-rule="evenodd" d="M8 12a.5.5 0 0 0 .5-.5V5.707l2.146 2.147a.5.5 0 0 0 .708-.708l-3-3a.5.5 0 0 0-.708 0l-3 3a.5.5 0 1 0 .708.708L7.5 5.707V11.5a.5.5 0 0 0 .5.5z"/>
-</svg>

--- a/content-images/wai-wcag-supplemental/caret-left.svg
+++ b/content-images/wai-wcag-supplemental/caret-left.svg
@@ -1,3 +1,0 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="currentColor" class="bi bi-caret-left" viewBox="0 0 16 16">
-  <path d="M10 12.796V3.204L4.519 8 10 12.796zm-.659.753-5.48-4.796a1 1 0 0 1 0-1.506l5.48-4.796A1 1 0 0 1 11 3.204v9.592a1 1 0 0 1-1.659.753z"/>
-</svg>

--- a/content-images/wai-wcag-supplemental/caret-left.svg
+++ b/content-images/wai-wcag-supplemental/caret-left.svg
@@ -1,0 +1,3 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="currentColor" class="bi bi-caret-left" viewBox="0 0 16 16">
+  <path d="M10 12.796V3.204L4.519 8 10 12.796zm-.659.753-5.48-4.796a1 1 0 0 1 0-1.506l5.48-4.796A1 1 0 0 1 11 3.204v9.592a1 1 0 0 1-1.659.753z"/>
+</svg>

--- a/content-images/wai-wcag-supplemental/caret-right.svg
+++ b/content-images/wai-wcag-supplemental/caret-right.svg
@@ -1,3 +1,0 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="currentColor" class="bi bi-caret-right" viewBox="0 0 16 16">
-  <path d="M6 12.796V3.204L11.481 8 6 12.796zm.659.753 5.48-4.796a1 1 0 0 0 0-1.506L6.66 2.451C6.011 1.885 5 2.345 5 3.204v9.592a1 1 0 0 0 1.659.753z"/>
-</svg>

--- a/content-images/wai-wcag-supplemental/caret-right.svg
+++ b/content-images/wai-wcag-supplemental/caret-right.svg
@@ -1,0 +1,3 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="currentColor" class="bi bi-caret-right" viewBox="0 0 16 16">
+  <path d="M6 12.796V3.204L11.481 8 6 12.796zm.659.753 5.48-4.796a1 1 0 0 0 0-1.506L6.66 2.451C6.011 1.885 5 2.345 5 3.204v9.592a1 1 0 0 0 1.659.753z"/>
+</svg>

--- a/content-images/wai-wcag-supplemental/caret-up.svg
+++ b/content-images/wai-wcag-supplemental/caret-up.svg
@@ -1,3 +1,0 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="currentColor" class="bi bi-caret-up" viewBox="0 0 16 16">
-  <path d="M3.204 11h9.592L8 5.519 3.204 11zm-.753-.659 4.796-5.48a1 1 0 0 1 1.506 0l4.796 5.48c.566.647.106 1.659-.753 1.659H3.204a1 1 0 0 1-.753-1.659z"/>
-</svg>

--- a/content-images/wai-wcag-supplemental/caret-up.svg
+++ b/content-images/wai-wcag-supplemental/caret-up.svg
@@ -1,0 +1,3 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="currentColor" class="bi bi-caret-up" viewBox="0 0 16 16">
+  <path d="M3.204 11h9.592L8 5.519 3.204 11zm-.753-.659 4.796-5.48a1 1 0 0 1 1.506 0l4.796 5.48c.566.647.106 1.659-.753 1.659H3.204a1 1 0 0 1-.753-1.659z"/>
+</svg>

--- a/content/about.md
+++ b/content/about.md
@@ -17,16 +17,16 @@ This page explains supplemental guidance for improving accessibility beyond what
 {% include box.html type="end" %}
 {:/}
 
-{::nomarkdown}
-{% include_cached toc.html type="start" title="Page Contents" %}
-{:/}
-
-- This will be replaced by an automatically generated TOC when using Markdown formatting.
-{:toc}
-
-{::nomarkdown}
-{% include_cached toc.html type="end" %}
-{:/}
+<nav class="box box-simple" aria-labelledby="tocheading" id="toc">
+  <header id="tocheading" class="box-h box-h-simple"> Page Contents</header>
+  <div class="box-i">
+    <ul id="markdown-toc">
+        <li><a href="#about-wcag-and-supplemental-guidance" id="markdown-toc-about-wcag-and-supplemental-guidance">About WCAG and Supplemental Guidance</a></li>
+        <li><a href="#-about-cognitive-accessibility-guidance" id="markdown-toc--about-cognitive-accessibility-guidance">About Cognitive Accessibility Guidance</a></li>
+        <li><a href="#about-low-vision-accessibility-guidance" id="markdown-toc-about-low-vision-accessibility-guidance">About Low Vision Accessibility Guidance</a></li>
+    </ul>
+  </div>
+</nav>
 
 ## About WCAG and Supplemental Guidance
 
@@ -39,21 +39,14 @@ Some accessibility issues did not fit as WCAG 2 requirements (called "success cr
 Following this guidance is not required to meet WCAG. And, we encourage you to follow this guidance in order meet more user needs.
 
 The accessibility issues addressed in this guidance are essential for people with certain disabilities to be able to use digital technology.
+## {% include image.html src="brain.svg" alt="" class="category-icon" %} About Cognitive Accessibility Guidance
 
-<div style="float:right; margin-left:1em;">
-{% include image.html src="brain.svg" alt="" class="mini" %}
-</div>
-## About Cognitive Accessibility Guidance
-
-This guidance provides a set of "Objectives" for reducing barriers experienced by people with cognitive and learning disabilities. The Objectives provide an overview and include a set of "Design Patterns". Each Design Pattern explains what to do in order to improve accessibility, how this helps when applied, and includes examples.
+The [Cognitive Accessibility Guidance](./all-supplemental-guidance/#-cognitive-accessibility-guidance) provides a set of "Objectives" for reducing barriers experienced by people with cognitive and learning disabilities. The Objectives provide an overview and include a set of "Design Patterns". Each Design Pattern explains what to do in order to improve accessibility, how this helps when applied, and includes examples.
 
 The Objectives and Design Patterns are from the more comprehensive document “[Making Content Usable for People with Cognitive and Learning Disabilities](https://www.w3.org/TR/coga-usable/)”. That document provides additional background, user stories, personas, a glossary, and other guidance.
 
 Broader information on cognitive accessibility in WCAG and on-going work on cognitive accessibility support at W3C WAI is in [Cognitive Accessibility at W3C <svg focusable="false" aria-hidden="true" class="icon-different-view "><use xlink:href="/assets/images/icons.svg#icon-different-view"></use></svg>](https://www.w3.org/WAI/cognitive/)
 
-<div style="float:right; margin-left:1em;">
-{% include image.html src="eye.svg" alt="" class="mini" %}
-</div>
-## About Low Vision Accessibility Guidance
+## {% include image.html src="eye.svg" alt="" class="category-icon" %}About Low Vision Accessibility Guidance
 
 Guidance on how to better meet the needs of people with low vision will be added in 2022.

--- a/content/about.md
+++ b/content/about.md
@@ -1,5 +1,4 @@
 ---
-doc-note-type: draft
 title: About Supplemental Guidance
 footer: ""
 permalink: /wcag-supplemental/about

--- a/content/supplemental-guidance.md
+++ b/content/supplemental-guidance.md
@@ -71,7 +71,7 @@ This guidance provides advice on how to better meet the accessibility needs of p
   {% include excol.html type="start" id=objective.ref %}
   <h3>{{ objective.title }}</h3>
   {% include excol.html type="middle" %}
-  <a href="{{ objective.url | relative_url }}">{{ objective.title }}</a>
+  Objective: <a href="{{ objective.url | relative_url }}">{{ objective.title }}</a>
   {% include patterns.html obj_ref = objective.ref %}
   {% include excol.html type="end" %}
 {% endfor %}

--- a/content/supplemental-guidance.md
+++ b/content/supplemental-guidance.md
@@ -23,24 +23,6 @@ inline_css: "
     color: inherit;
   }
 "
-#  summary > :first-child::before
-#  {
-#    display: none;
-#  }
-#  summary > :first-child::marker
-#  {
-#    content: \"\";
-#  }
-#  summary > :first-child > span
-#  {
-#    display: list-item;
-#    list-style-position: inside;
-#    list-style-type: disc;
-#  }
-#  div[data-details][aria-expanded=false] div:not([data-summary])
-#  {
-#    display:none;
-#  }
 ---
 
 
@@ -54,16 +36,17 @@ This pages lists [supplemental guidance](/wcag-supplemental/about/) for improvin
 {% include box.html type="end" %}
 {:/}
 
-{::nomarkdown}
-{% include_cached toc.html type="start" title="Page Contents" %}
-{:/}
+<nav class="box box-simple" aria-labelledby="tocheading" id="toc">
+  <header id="tocheading" class="box-h box-h-simple"> Page Contents</header>
+  <div class="box-i">
 
-- This will be replaced by an automatically generated TOC when using Markdown formatting.
-{:toc}
+<ul id="markdown-toc">
+  <li><a href="#-cognitive-accessibility-guidance" id="markdown-toc--cognitive-accessibility-guidance">Cognitive Accessibility Guidance</a></li>
+  <li><a href="#-low-vision-accessibility-guidance" id="markdown-toc--low-vision-accessibility-guidance">Low Vision Accessibility Guidance</a></li>
+</ul>
 
-{::nomarkdown}
-{% include_cached toc.html type="end" %}
-{:/}
+  </div>
+</nav>
 
 ## {% include image.html src="brain.svg" alt="" class="mini" %} Cognitive Accessibility Guidance
 

--- a/content/supplemental-guidance.md
+++ b/content/supplemental-guidance.md
@@ -17,7 +17,11 @@ inline_css: "
     height: 2em;
     vertical-align: middle;
     padding-bottom: 0.25em;
-  }  
+  }
+  details h4 {
+    font-size: 1rem;
+    color: inherit;
+  }
 "
 #  summary > :first-child::before
 #  {
@@ -72,6 +76,7 @@ This guidance provides advice on how to better meet the accessibility needs of p
   <h3>{{ objective.title }}</h3>
   {% include excol.html type="middle" %}
   Objective: <a href="{{ objective.url | relative_url }}">{{ objective.title }}</a>
+  <h4>Design Patterns:</h4>
   {% include patterns.html obj_ref = objective.ref %}
   {% include excol.html type="end" %}
 {% endfor %}

--- a/content/supplemental-guidance.md
+++ b/content/supplemental-guidance.md
@@ -39,12 +39,10 @@ This pages lists [supplemental guidance](/wcag-supplemental/about/) for improvin
 <nav class="box box-simple" aria-labelledby="tocheading" id="toc">
   <header id="tocheading" class="box-h box-h-simple"> Page Contents</header>
   <div class="box-i">
-
-<ul id="markdown-toc">
-  <li><a href="#-cognitive-accessibility-guidance" id="markdown-toc--cognitive-accessibility-guidance">Cognitive Accessibility Guidance</a></li>
-  <li><a href="#-low-vision-accessibility-guidance" id="markdown-toc--low-vision-accessibility-guidance">Low Vision Accessibility Guidance</a></li>
-</ul>
-
+    <ul id="markdown-toc">
+        <li><a href="#-cognitive-accessibility-guidance" id="markdown-toc--cognitive-accessibility-guidance">Cognitive Accessibility Guidance</a></li>
+        <li><a href="#-low-vision-accessibility-guidance" id="markdown-toc--low-vision-accessibility-guidance">Low Vision Accessibility Guidance</a></li>
+    </ul>
   </div>
 </nav>
 

--- a/content/supplemental-guidance.md
+++ b/content/supplemental-guidance.md
@@ -11,6 +11,12 @@ feedbackemail: wai@w3.org
 inline_css: "
   details ul {
       margin-top: 1rem;
+  }
+  h2 img.mini {
+    width: 2em;
+    height: 2em;
+    vertical-align: middle;
+    padding-bottom: 0.25em;
   }  
 "
 #  summary > :first-child::before
@@ -55,10 +61,7 @@ This pages lists [supplemental guidance](/wcag-supplemental/about/) for improvin
 {% include_cached toc.html type="end" %}
 {:/}
 
-<div style="float:right; margin-left:1em;">
-{% include image.html src="brain.svg" alt="" class="mini" %}
-</div>
-## Cognitive Accessibility Guidance
+## {% include image.html src="brain.svg" alt="" class="mini" %} Cognitive Accessibility Guidance
 
 This guidance provides advice on how to better meet the accessibility needs of people with cognitive and learning disabilities. The guidance listed below is grouped under "Objectives" and provided in "Design Patterns".
 
@@ -75,9 +78,6 @@ This guidance provides advice on how to better meet the accessibility needs of p
 
 {% include excol.html type="all" %}
 
-<div style="float:right; margin-left:1em;">
-{% include image.html src="eye.svg" alt="" class="mini" %}
-</div>
-## Low Vision Accessibility Guidance
+## {% include image.html src="eye.svg" alt="" class="mini" %} Low Vision Accessibility Guidance
 
 Guidance on how to better meet the needs of people with low vision will be added in 2022.

--- a/content/supplemental-guidance.md
+++ b/content/supplemental-guidance.md
@@ -1,5 +1,4 @@
 ---
-doc-note-type: draft
 title: All Supplemental Guidance
 footer: ""
 permalink: /wcag-supplemental/all-supplemental-guidance

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,6 @@
+{
+  "name": "wai-wcag-supplemental",
+  "lockfileVersion": 2,
+  "requires": true,
+  "packages": {}
+}


### PR DESCRIPTION
nothing earth-shatteringly different, but just pulls things together/tidies them a bit

* removes invalid markup structures (`em` and `span` as child of `ul`?) and simplifies matters a bit
* overrides a lot of the existing style rules and adds custom styling (inline at the top of the `<style>` section)
* new up/left/right svg icons (added inline for styling, added .svg file as backup in the images folder)
* sets explicit link colour (especially for visited links)
* general tweaks

compare https://wai-wcag-supplemental.netlify.app/wcag-supplemental/patterns/o3p11-unobscured-foreground/ with https://deploy-preview-51--wai-wcag-supplemental.netlify.app/wcag-supplemental/patterns/o3p11-unobscured-foreground/