### PR TITLE
White Spacing → White Space

### DIFF
--- a/_collections/_patterns/o3p10-whitespace.html
+++ b/_collections/_patterns/o3p10-whitespace.html
@@ -1,5 +1,5 @@
 ---
-title: Use White Spacing
+title: Use White Space
 ref: o3p10
 github: 
   repository: w3c/wai-wcag-supplemental


### PR DESCRIPTION
It’s called White Space everywhere else in the document. (The document also refers to letter and word spacing here, which are related concepts but should not be conflated with “White Space”.