### PR TITLE
Use the same month period in the good and bad examples

### DIFF
--- a/_collections/_patterns/o3p02-simple-tense.html
+++ b/_collections/_patterns/o3p02-simple-tense.html
@@ -80,7 +80,7 @@ related:
   <p><span class="use"></span><strong>Use:</strong></p>
   <ol>
     <li>
-      Simple tense and language. For example: “Your stocks went up this month.”
+      Simple tense and language. For example: “Your stocks went up last month.”
     </li>
   </ol>
   <p><span class="avoid"></span><strong>Avoid:</strong></p>


### PR DESCRIPTION
“This month” and “last month” are sometimes squishy phrases – for example, you might refer to this month a few days in the next month. Context matters. To make this easiest to read for everyone, but especially people covered by the COGA TF, I would even suggest changing “last month” to a specific month, for example “April”.

But at least, the examples should refer to the same squishy month.